### PR TITLE
Sonar cub testing integration ramses

### DIFF
--- a/BAM/pom.xml
+++ b/BAM/pom.xml
@@ -48,6 +48,25 @@
 					<warSourceDirectory>src/main/webapp</warSourceDirectory>
 				</configuration>
 			</plugin>
+			<plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.7.201606060606</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 	<!-- https://mvnrepository.com/artifact/org.jasypt/jasypt -->


### PR DESCRIPTION
Added Maven plugin, jcoco, to our pom so that SonarQube can recognize our tests.